### PR TITLE
add structure.id

### DIFF
--- a/examples/example_1.cif
+++ b/examples/example_1.cif
@@ -1,0 +1,112 @@
+#\#CIF_2.0
+##
+# Two datablocks present two structures. A third datablock contains experimental
+# conditions.
+#
+# In the below example, it isn't strictly necessary to explicitly give values to
+# _structure.id or _space_group.id, as there is only one present per block.
+#
+# A representation of the resultant merged data is given in example_1_merged.cif
+#
+##
+
+
+data_conditions
+_diffrn.id DIFCON_1
+_diffrn.ambient_temperature  900
+
+
+
+data_blockname_one
+_structure.id A   # Must be unique.
+_structure.diffrn_id  DIFCON_1
+
+_cell.length_a            5.4469
+_cell.length_b            5.4469
+_cell.length_c            5.4469
+_cell.angle_alpha        90
+_cell.angle_beta         90
+_cell.angle_gamma        90
+_cell.volume            161.61
+_cell.formula_units_Z     4
+
+_space_group.id 1 # Must be unique.
+                  # Can be the same if representing the:
+                  #    same space group name and number
+                  #    same setting
+                  #    same symops with the same id values
+_space_group.crystal_system	  cubic
+_space_group.name_H-M_alt     Fm-3m
+
+loop_
+  _space_group_symop_id
+  _space_group_symop_operation_xyz
+    1 'x, y, z '
+    2 '-x, -y, z '
+  #...
+  191 'x, y+1/2, -z+1/2 '
+  192 '-x, -y+1/2, -z+1/2 '
+
+loop_
+  _atom_site.label
+  _atom_site.type_symbol
+  _atom_site.fract_xyz
+  _atom_site.B_iso_or_equiv
+Mn1 Mn+2 [0   0   0]   0.2
+Se1 Se   [0.5 0.5 0.5] 0.4
+
+loop_
+  _atom_site_aniso.label
+  _atom_site_aniso.b_11
+  _atom_site_aniso.b_12
+  _atom_site_aniso.b_13
+  _atom_site_aniso.b_22
+  _atom_site_aniso.b_23
+  _atom_site_aniso.b_33
+Mn1 0.2 0.05 0.08 0.2 0.03 0.2
+
+
+
+data_blockname2
+_structure.id B   #Must be unique.
+_structure.diffrn_id  DIFCON_1
+
+_cell.length_a            3.0205
+_cell.length_b            3.0205
+_cell.length_c            3.0205
+_cell.angle_alpha        90
+_cell.angle_beta         90
+_cell.angle_gamma        90
+_cell.volume             27.558
+_cell.formula_units_Z	  2
+
+_space_group.id 2 # Must be unique.
+                  # Can be the same if representing the:
+                  #    same space group name and number
+                  #    same setting
+                  #    same symops with the same id values
+_space_group.crystal_system	cubic
+_space_group.name_H-M_alt Im-3m
+loop_
+  _space_group.symop_id
+  _space_group.symop_operation_xyz
+    1 'x, y, z '
+    2 '-x, -y, z '
+   #...
+   95 'x+1/2, y+1/2, -z+1/2 '
+   96 '-x+1/2, -y+1/2, -z+1/2 '
+
+loop_
+  _atom_site.label
+  _atom_site.type_symbol
+  _atom_site.fract_xyz
+  _atom_site.B_iso_or_equiv
+V1 V [0 0 0] 0.5
+
+###################################
+#
+#  End of the CIF file
+#
+###################################
+
+

--- a/examples/example_1.cif
+++ b/examples/example_1.cif
@@ -1,51 +1,51 @@
 #\#CIF_2.0
 ##
-# Two datablocks present two structures. A third datablock contains experimental
-# conditions.
+# Data blocks 'block_one' and 'block_two' present two structures.
+# The 'conditions' data block contains experimental conditions.
 #
-# In the below example, it isn't strictly necessary to explicitly give values to
-# _structure.id or _space_group.id, as there is only one present per block.
+# In the below example, it is not strictly necessary to explicitly give values
+# to _structure.id or _space_group.id, as there is only one present per block.
 #
-# A representation of the resultant merged data is given in example_1_merged.cif
-#
+# A representation of the resultant merged data is given in
+# example_1_merged.cif.
 ##
 
 
 data_conditions
 _diffrn.id DIFCON_1
-_diffrn.ambient_temperature  900
+_diffrn.ambient_temperature   900
 
 
 
-data_blockname_one
+data_block_one
 _structure.id A   # Must be unique.
 _structure.diffrn_id  DIFCON_1
 
-_cell.length_a            5.4469
-_cell.length_b            5.4469
-_cell.length_c            5.4469
-_cell.angle_alpha        90
-_cell.angle_beta         90
-_cell.angle_gamma        90
-_cell.volume            161.61
-_cell.formula_units_Z     4
+_cell.length_a                5.4469
+_cell.length_b                5.4469
+_cell.length_c                5.4469
+_cell.angle_alpha             90
+_cell.angle_beta              90
+_cell.angle_gamma             90
+_cell.volume                  161.61
+_cell.formula_units_Z         4
 
 _space_group.id 1 # Must be unique.
                   # Can be the same if representing the:
                   #    same space group name and number
                   #    same setting
                   #    same symops with the same id values
-_space_group.crystal_system	  cubic
+_space_group.crystal_system   cubic
 _space_group.name_H-M_alt     Fm-3m
 
 loop_
   _space_group_symop_id
   _space_group_symop_operation_xyz
-    1 'x, y, z '
-    2 '-x, -y, z '
+    1 'x, y, z'
+    2 '-x, -y, z'
   #...
-  191 'x, y+1/2, -z+1/2 '
-  192 '-x, -y+1/2, -z+1/2 '
+  191 'x, y+1/2, -z+1/2'
+  192 '-x, -y+1/2, -z+1/2'
 
 loop_
   _atom_site.label
@@ -67,34 +67,34 @@ Mn1 0.2 0.05 0.08 0.2 0.03 0.2
 
 
 
-data_blockname2
-_structure.id B   #Must be unique.
+data_block_two
+_structure.id B   # Must be unique.
 _structure.diffrn_id  DIFCON_1
 
-_cell.length_a            3.0205
-_cell.length_b            3.0205
-_cell.length_c            3.0205
-_cell.angle_alpha        90
-_cell.angle_beta         90
-_cell.angle_gamma        90
-_cell.volume             27.558
-_cell.formula_units_Z	  2
+_cell.length_a                3.0205
+_cell.length_b                3.0205
+_cell.length_c                3.0205
+_cell.angle_alpha             90
+_cell.angle_beta              90
+_cell.angle_gamma             90
+_cell.volume                  27.558
+_cell.formula_units_Z         2
 
 _space_group.id 2 # Must be unique.
                   # Can be the same if representing the:
                   #    same space group name and number
                   #    same setting
                   #    same symops with the same id values
-_space_group.crystal_system	cubic
-_space_group.name_H-M_alt Im-3m
+_space_group.crystal_system cubic
+_space_group.name_H-M_alt     Im-3m
 loop_
   _space_group.symop_id
   _space_group.symop_operation_xyz
-    1 'x, y, z '
-    2 '-x, -y, z '
+    1 'x, y, z'
+    2 '-x, -y, z'
    #...
-   95 'x+1/2, y+1/2, -z+1/2 '
-   96 '-x+1/2, -y+1/2, -z+1/2 '
+   95 'x+1/2, y+1/2, -z+1/2'
+   96 '-x+1/2, -y+1/2, -z+1/2'
 
 loop_
   _atom_site.label
@@ -108,5 +108,3 @@ V1 V [0 0 0] 0.5
 #  End of the CIF file
 #
 ###################################
-
-

--- a/examples/example_1_merged.cif
+++ b/examples/example_1_merged.cif
@@ -1,0 +1,79 @@
+#\#CIF_2.0
+##
+#  A representation of a merged datablock for the data given in example_1.cif.
+#
+#  It shouldn't actually be used this way to construct a CIF file, but this
+#  maps out how the relational tables would be populated.
+#
+##
+
+
+
+data_merged
+loop_
+  _diffrn.id
+  _diffrn.ambient_temperature
+DIFCON_1  900
+
+loop_
+  _structure.id
+  _structure.space_group_id
+  _structure.diffrn_id
+A 1 DIFCON_1
+B 2 DIFCON_1
+
+loop_
+  _cell.structure_id
+  _cell.length_a
+  _cell.length_b
+  _cell.length_c
+  _cell.angle_alpha
+  _cell.angle_beta
+  _cell.angle_gamma
+  _cell.volume
+  _cell.formula_units_Z
+A  5.4469 5.4469 5.4469 90 90 90 161.61  4
+B  3.0205 3.0205 3.0205 90 90 90  27.558 2
+
+loop_
+  _space_group.id
+  _space_group.crystal_system
+  _space_group.name_H-M_alt
+1 cubic Fm-3m
+2 cubic Im-3m
+
+loop_
+  _space_group_symop.space_group_id
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+1   1 'x, y, z '
+1   2 '-x, -y, z '
+#...
+1 191 'x, y+1/2, -z+1/2 '
+1 192 '-x, -y+1/2, -z+1/2 '
+2   1 'x, y, z '
+2   2 '-x, -y, z '
+#...
+2  95 'x+1/2, y+1/2, -z+1/2 '
+2  96 '-x+1/2, -y+1/2, -z+1/2 '
+
+loop_
+  _atom_site.structure_id
+  _atom_site.label
+  _atom_site.type_symbol
+  _atom_site.fract_xyz
+  _atom_site.B_iso_or_equiv
+A Mn1 Mn+2 [0   0   0]   0.2
+A Se1 Se   [0.5 0.5 0.5] 0.4
+B V1  V    [0   0   0]   0.5
+
+loop_
+  _atom_site_aniso.structure_id
+  _atom_site_aniso.label
+  _atom_site_aniso.b_11
+  _atom_site_aniso.b_12
+  _atom_site_aniso.b_13
+  _atom_site_aniso.b_22
+  _atom_site_aniso.b_23
+  _atom_site_aniso.b_33
+A Mn1 0.2 0.05 0.08 0.2 0.03 0.2

--- a/examples/example_1_merged.cif
+++ b/examples/example_1_merged.cif
@@ -1,13 +1,10 @@
 #\#CIF_2.0
 ##
-#  A representation of a merged datablock for the data given in example_1.cif.
+# A representation of a merged data block for the data given in example_1.cif.
 #
-#  It shouldn't actually be used this way to construct a CIF file, but this
-#  maps out how the relational tables would be populated.
-#
+# It should not actually be used this way to construct a CIF file, but this
+# maps out how the relational tables would be populated.
 ##
-
-
 
 data_merged
 loop_
@@ -32,8 +29,8 @@ loop_
   _cell.angle_gamma
   _cell.volume
   _cell.formula_units_Z
-A  5.4469 5.4469 5.4469 90 90 90 161.61  4
-B  3.0205 3.0205 3.0205 90 90 90  27.558 2
+A  5.4469 5.4469 5.4469 90 90 90 161.61 4
+B  3.0205 3.0205 3.0205 90 90 90 27.558 2
 
 loop_
   _space_group.id
@@ -46,16 +43,16 @@ loop_
   _space_group_symop.space_group_id
   _space_group_symop.id
   _space_group_symop.operation_xyz
-1   1 'x, y, z '
-1   2 '-x, -y, z '
+1   1 'x, y, z'
+1   2 '-x, -y, z'
 #...
-1 191 'x, y+1/2, -z+1/2 '
-1 192 '-x, -y+1/2, -z+1/2 '
-2   1 'x, y, z '
-2   2 '-x, -y, z '
+1 191 'x, y+1/2, -z+1/2'
+1 192 '-x, -y+1/2, -z+1/2'
+2   1 'x, y, z'
+2   2 '-x, -y, z'
 #...
-2  95 'x+1/2, y+1/2, -z+1/2 '
-2  96 '-x+1/2, -y+1/2, -z+1/2 '
+2  95 'x+1/2, y+1/2, -z+1/2'
+2  96 '-x+1/2, -y+1/2, -z+1/2'
 
 loop_
   _atom_site.structure_id

--- a/examples/example_2.cif
+++ b/examples/example_2.cif
@@ -1,0 +1,45 @@
+#\#CIF_2.0
+##
+#  A pathalogical example of how structure information is disparate datablocks
+#  can be gathered to form a single structure representation.
+#
+#  The first set of datablocks provides the data, and the final datablock gives
+#  a representation of how the resultant relational tables could be constructed.
+#
+#  It shouldn't actually be used this way to construct a CIF file, but this
+#  maps out how the relational tables would be populated.
+#
+##
+
+# source data
+data_block1
+  _structure.id A
+  _cell.length_a 12.3456
+data_block2
+  _structure.id A
+  _cell.length_b 12.3456
+data_block3
+  _structure.id A
+  _cell.length_c 12.3456
+data_block4
+  _structure.id A
+  _cell.angle_alpha 90
+data_block5
+  _structure.id A
+  _cell.angle_beta 90
+data_block6
+  _structure.id A
+  _cell.angle_gamma 90
+
+
+# relational table
+data_merged
+loop_
+  _cell.structure_id
+  _cell.length_a
+  _cell.length_b
+  _cell.length_c
+  _cell.angle_alpha
+  _cell.angle_beta
+  _cell.angle_gamma
+A 12.3456 12.3456 12.3456 90 90 90

--- a/examples/example_2.cif
+++ b/examples/example_2.cif
@@ -1,33 +1,32 @@
 #\#CIF_2.0
 ##
-#  A pathalogical example of how structure information is disparate datablocks
-#  can be gathered to form a single structure representation.
+# A pathalogical example of how structure information is disparate data blocks
+# can be gathered to form a single structure representation.
 #
-#  The first set of datablocks provides the data, and the final datablock gives
-#  a representation of how the resultant relational tables could be constructed.
+# The first set of data blocks provides the data, and the final data block gives
+# a representation of how the resultant relational tables could be constructed.
 #
-#  It shouldn't actually be used this way to construct a CIF file, but this
-#  maps out how the relational tables would be populated.
-#
+# It should npt actually be used this way to construct a CIF file, but this
+# maps out how the relational tables would be populated.
 ##
 
 # source data
-data_block1
+data_block_1
   _structure.id A
   _cell.length_a 12.3456
-data_block2
+data_block_2
   _structure.id A
   _cell.length_b 12.3456
-data_block3
+data_block_3
   _structure.id A
   _cell.length_c 12.3456
-data_block4
+data_block_4
   _structure.id A
   _cell.angle_alpha 90
-data_block5
+data_block_5
   _structure.id A
   _cell.angle_beta 90
-data_block6
+data_block_6
   _structure.id A
   _cell.angle_gamma 90
 

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -317,10 +317,14 @@ save_
 save_space_group.id
 
     _definition.id                '_space_group.id'
-    _definition.update            2023-10-16
+    _definition.update            2023-10-25
     _description.text
 ;
     Unique identifier for a space group.
+
+    Two space groups can share the same identifier if and only if they have
+    the same space group name, number, setting, and have their their symmetry
+    operations listed with the same symop ids (see SPACE_GROUP_SYMOP).
 ;
     _name.category_id             space_group
     _name.object_id               id

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -675,7 +675,7 @@ save_atom_site_aniso.structure_id
 ;
     _name.category_id             atom_site_aniso
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
+    _name.linked_item_id          '_atom_site.structure_id'
     _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -124,6 +124,29 @@ save_CELL
 
 save_
 
+save_cell.diffrn_id
+
+    _definition.id                '_cell.diffrn_id'
+    _definition.update            2023-10-26
+    _description.text
+;
+    A pointer to the diffraction conditions to which this cell has been applied,
+    for example, to locate and extract diffraction peaks. These will normally be
+    the same conditions as those under which the cell was measured, but some
+    legacy data sets may have used a cell measured under differing conditions,
+    in which case those conditions should be indicated using the
+    _cell_measurement.condition_id data item.
+;
+    _name.category_id             cell
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_cell.structure_id
 
     _definition.id                '_cell.structure_id'
@@ -181,6 +204,25 @@ save_cell_measurement.condition_id
 ;
     _enumeration.default = _cell_measurement.diffrn_id
 ;
+
+save_
+
+save_cell_measurement.diffrn_id
+
+    _definition.id                '_cell_measurement.diffrn_id'
+    _definition.update            2023-10-26
+    _description.text
+;
+    A pointer to the diffraction experiment to which the measured cell
+    has been applied.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
 
 save_
 

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -485,7 +485,7 @@ save_STRUCTURE
 ;
     A category for collecting information about a crystallographic structure.
 ;
-    _name.category_id             CIF_CORE
+    _name.category_id             MULTIBLOCK_CORE
     _name.object_id               STRUCTURE
     _category_key.name            '_structure.id'
 

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -120,28 +120,23 @@ save_CELL
 ;
     _name.category_id             DIFFRN
     _name.object_id               CELL
-    _category_key.name            '_cell.diffrn_id'
+    _category_key.name            '_cell.structure_id'
 
 save_
 
-save_cell.diffrn_id
+save_cell.structure_id
 
-    _definition.id                '_cell.diffrn_id'
-    _definition.update            2023-02-01
+    _definition.id                '_cell.structure_id'
+    _definition.update            2023-10-16
     _description.text
 ;
-    A pointer to the diffraction conditions to which this cell has been applied,
-    for example, to locate and extract diffraction peaks. These will normally be
-    the same conditions as those under which the cell was measured, but some
-    legacy data sets may have used a cell measured under differing conditions,
-    in which case those conditions should be indicated using the
-    _cell_measurement.condition_id data item.
+    A code identifying the structure to which this atom site belongs.
 ;
     _name.category_id             cell
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
     _type.purpose                 Link
-    _type.source                  Related
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
 
@@ -160,7 +155,7 @@ save_CELL_MEASUREMENT
 ;
     _name.category_id             CELL
     _name.object_id               CELL_MEASUREMENT
-    _category_key.name            '_cell_measurement.diffrn_id'
+    _category_key.name            '_cell_measurement.structure_id'
 
 save_
 
@@ -189,20 +184,60 @@ save_cell_measurement.condition_id
 
 save_
 
-save_cell_measurement.diffrn_id
+save_cell_measurement.structure_id
 
-    _definition.id                '_cell_measurement.diffrn_id'
-    _definition.update            2023-02-01
+    _definition.id                '_cell_measurement.structure_id'
+    _definition.update            2023-10-16
     _description.text
 ;
-    A pointer to the diffraction experiment to which the measured cell
-    has been applied.
+    A code identifying the structure to which the cell belongs.
 ;
     _name.category_id             cell_measurement
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
     _type.purpose                 Link
-    _type.source                  Related
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_CELL_MEASUREMENT_REFLN
+
+    _definition.id                CELL_MEASUREMENT_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe the reflection data
+    used in the measurement of the crystal unit cell.
+;
+    _name.category_id             CELL_MEASUREMENT
+    _name.object_id               CELL_MEASUREMENT_REFLN
+
+    loop_
+      _category_key.name
+         '_cell_measurement_refln.index_h'
+         '_cell_measurement_refln.index_k'
+         '_cell_measurement_refln.index_l'
+         '_cell_measurement_refln.structure_id'
+
+save_
+
+save_cell_measurement_refln.structure_id
+
+    _definition.id                '_cell_measurement_refln.structure_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code identifying the structure for which the reflections were measured.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
 
@@ -237,6 +272,388 @@ save_exptl_crystal.id
     _name.category_id             exptl_crystal
     _name.object_id               id
     _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP
+
+    _definition.id                SPACE_GROUP
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to specify space group
+    information about the crystal used in the diffraction measurements.
+
+    Space-group types are identified by their number as listed in
+    International Tables for Crystallography Volume A, or by their
+    Schoenflies symbol. Specific settings of the space groups can
+    be identified by their Hall symbol, by specifying their
+    symmetry operations or generators, or by giving the
+    transformation that relates the specific setting to the
+    reference setting based on International Tables Volume A and
+    stored in this dictionary.
+
+    The commonly used Hermann-Mauguin symbol determines the
+    space-group type uniquely, but several different Hermann-Mauguin
+    symbols may refer to the same space-group type. A
+    Hermann-Mauguin symbol contains information on the choice of
+    the basis, but not on the choice of origin.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             EXPTL
+    _name.object_id               SPACE_GROUP
+    _category_key.name            '_space_group.id'
+
+save_
+
+save_space_group.id
+
+    _definition.id                '_space_group.id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    Unique identifier for a space group.
+;
+    _name.category_id             space_group
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP_GENERATOR
+
+    _definition.id                SPACE_GROUP_GENERATOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to list generators for
+    the space group
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_GENERATOR
+
+    loop_
+      _category_key.name
+         '_space_group_generator.key'
+         '_space_group_generator.space_group_id'
+
+save_
+
+save_space_group_generator.space_group_id
+
+    _definition.id                '_space_group_generator.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group to which the generator belongs.
+;
+    _name.category_id             space_group_generator
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP_SYMOP
+
+    _definition.id                SPACE_GROUP_SYMOP
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe symmetry equivalent sites
+    in the crystal unit cell.
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_SYMOP
+
+    loop_
+      _category_key.name
+         '_space_group_symop.id'
+         '_space_group_symop.space_group_id'
+
+save_
+
+save_space_group_symop.space_group_id
+
+    _definition.id                '_space_group_symop.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group to which the symop belongs.
+;
+    _name.category_id             space_group_symop
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP_WYCKOFF
+
+    _definition.id                SPACE_GROUP_WYCKOFF
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    Contains information about Wyckoff positions of a space group.
+    Only one site can be given for each special position, but the
+    remainder can be generated by applying the symmetry operations
+    stored in _space_group_symop.operation_xyz.
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_WYCKOFF
+
+    loop_
+      _category_key.name
+         '_space_group_Wyckoff.id'
+         '_space_group_Wyckoff.space_group_id'
+
+save_
+
+save_space_group_wyckoff.space_group_id
+
+    _definition.id                '_space_group_Wyckoff.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group to which the Wyckoff position
+    belongs.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_STRUCTURE
+
+    _definition.id                STRUCTURE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-10-16
+    _description.text
+;
+    The DICTIONARY group encompassing the CORE STRUCTURE data items defined
+    and used within the Crystallographic Information Framework (CIF).
+;
+    _name.category_id             CIF_CORE
+    _name.object_id               STRUCTURE
+    _category_key.name            '_structure.id'
+
+save_
+
+save_structure.diffrn_id
+
+    _definition.id                '_structure.diffrn_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the diffraction conditions under which the data for
+    this structure were collected.
+;
+    _name.category_id             structure
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_structure.id
+
+    _definition.id                '_structure.id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    Unique identifier for a structure.
+;
+    _name.category_id             structure
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_structure.space_group_id
+
+    _definition.id                '_structure.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group associated with the structure.
+;
+    _name.category_id             structure
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_ATOM_SITE
+
+    _definition.id                ATOM_SITE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe atom site information
+    used in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SITE
+
+    loop_
+      _category_key.name
+         '_atom_site.label'
+         '_atom_site.structure_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+           _atom_site.label
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            C1     1      .     .
+            H11A   .5     M     1
+            H12A   .5     M     1
+            H13A   .5     M     1
+            H11B   .5     M     2
+            H12B   .5     M     2
+            H13B   .5     M     2
+;
+;
+         A hypothetical example of a positional disorder description. Disorder
+         assembly 'M' describes a methyl group with two alternative
+         configurations '1' and '2':
+
+                            H11B    H11A      H13B
+                              .      |      .
+                                .    |    .
+                                  .  |  .
+                                     C1 --------C2---
+                                   / .  \
+                                 /   .    \
+                               /     .      \
+                            H12A    H12B    H13A
+;
+;
+         loop_
+           _atom_site.label
+           _atom_site.type_symbol
+           _atom_site.fract_x
+           _atom_site.fract_y
+           _atom_site.fract_z
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            Cu1 Cu 0.78443(2) 0.88297(4) 0.37825(2)  1       . .
+            Co1 Co 0.77504(2) 0.66957(4) 0.54249(2)  0.78(3) A 1
+            Mn1 Mn 0.77504(2) 0.66957(4) 0.54249(2)  0.22(3) A 2
+            O1   O 0.85532(9) 0.95747(19) 0.28965(9) 1       . .
+            O2   O 0.84868(9) 0.94662(19) 0.14953(8) 1       . .
+            # ...
+;
+;
+         An example of a compositional disorder description. Disorder assembly
+         'A' describes a site that is simultaneously occupied by Co and Mn
+         atoms which are assigned to disorder group '1' and disorder group '2'
+         respectively.
+
+         The example was created based on data from:
+             Li, Ang et al. (2021). Dalton Transactions, 50(2), 681-688.
+             https://doi.org/10.1039/d0dt03269g
+;
+
+save_
+
+save_atom_site.structure_id
+
+    _definition.id                '_atom_site.structure_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code identifying the structure to which this atom site belongs.
+;
+    _name.category_id             atom_site
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_ATOM_SITE_ANISO
+
+    _definition.id                ATOM_SITE_ANISO
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe the anisotropic atomic
+    displacement parameters of the atomic sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITE
+    _name.object_id               ATOM_SITE_ANISO
+
+    loop_
+      _category_key.name
+         '_atom_site_aniso.label'
+         '_atom_site_aniso.structure_id'
+
+save_
+
+save_atom_site_aniso.structure_id
+
+    _definition.id                '_atom_site_aniso.structure_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code identifying the structure to which this atom site belongs.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Word

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -10,7 +10,7 @@ data_MULTIBLOCK_DIC
     _dictionary.title             MULTIBLOCK_DIC
     _dictionary.class             Instance
     _dictionary.version           1.1.0
-    _dictionary.date              2023-10-26
+    _dictionary.date              2024-02-05
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/multi_block_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -124,36 +124,14 @@ save_CELL
 
 save_
 
-save_cell.diffrn_id
-
-    _definition.id                '_cell.diffrn_id'
-    _definition.update            2023-10-26
-    _description.text
-;
-    A pointer to the diffraction conditions to which this cell has been applied,
-    for example, to locate and extract diffraction peaks. These will normally be
-    the same conditions as those under which the cell was measured, but some
-    legacy data sets may have used a cell measured under differing conditions,
-    in which case those conditions should be indicated using the
-    _cell_measurement.condition_id data item.
-;
-    _name.category_id             cell
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_cell.structure_id
 
     _definition.id                '_cell.structure_id'
-    _definition.update            2023-10-16
+    _definition.update            2024-02-05
     _description.text
 ;
-    A code identifying the structure to which this atom site belongs.
+    A code identifying the crystallographic structure associated with this cell
+    description.
 ;
     _name.category_id             cell
     _name.object_id               structure_id
@@ -229,10 +207,10 @@ save_
 save_cell_measurement.structure_id
 
     _definition.id                '_cell_measurement.structure_id'
-    _definition.update            2023-10-16
+    _definition.update            2024-02-05
     _description.text
 ;
-    A code identifying the structure to which the cell belongs.
+    A code identifying the structure to which the cell being measured belongs.
 ;
     _name.category_id             cell_measurement
     _name.object_id               structure_id
@@ -713,9 +691,12 @@ save_
 ;
        All multi-block items from core 3.2.0 added.
 ;
-         1.1.0                    2023-10-26
+         1.1.0                    2024-02-05
 ;
        # Update date above and add audit comments below. Remove
        this comment when ready for release.
 
        Add STRUCTURE and related data names and links.
+
+       Update definitions of _cell.structure_id and
+       _cell_measurement.structure_id. Removed _cell.diffrn_id.

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -10,7 +10,7 @@ data_MULTIBLOCK_DIC
     _dictionary.title             MULTIBLOCK_DIC
     _dictionary.class             Instance
     _dictionary.version           1.1.0
-    _dictionary.date              2023-09-28
+    _dictionary.date              2023-10-25
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/multi_block_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -456,11 +456,10 @@ save_STRUCTURE
     _definition.id                STRUCTURE
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2023-10-16
+    _definition.update            2023-10-25
     _description.text
 ;
-    The DICTIONARY group encompassing the CORE STRUCTURE data items defined
-    and used within the Crystallographic Information Framework (CIF).
+    A category for collecting information about a crystallographic structure.
 ;
     _name.category_id             CIF_CORE
     _name.object_id               STRUCTURE
@@ -668,7 +667,9 @@ save_
 ;
        All multi-block items from core 3.2.0 added.
 ;
-         1.1.0                    2023-09-28
+         1.1.0                    2023-10-25
 ;
        # Update date above and add audit comments below. Remove
        this comment when ready for release.
+
+       Add STRUCTURE and related data names and links.

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -10,7 +10,7 @@ data_MULTIBLOCK_DIC
     _dictionary.title             MULTIBLOCK_DIC
     _dictionary.class             Instance
     _dictionary.version           1.1.0
-    _dictionary.date              2023-10-25
+    _dictionary.date              2023-10-26
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/multi_block_core.dic
     _dictionary.ddl_conformance   4.2.0
@@ -713,7 +713,7 @@ save_
 ;
        All multi-block items from core 3.2.0 added.
 ;
-         1.1.0                    2023-10-25
+         1.1.0                    2023-10-26
 ;
        # Update date above and add audit comments below. Remove
        this comment when ready for release.

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -700,3 +700,4 @@ save_
 
        Update definitions of _cell.structure_id and
        _cell_measurement.structure_id. Removed _cell.diffrn_id.
+;


### PR DESCRIPTION
Will close #3 

I redid the PR, as I wanted to work through things in my head.

There are now:

- `STRUCTURE`
   - `id`
   - `space_group_id`
   - `diffrn_id`
- `ATOM_SITE`, `ATOM_SITE_ANISO`, `CELL`, `CELL_MEASUREMENT`, and `CELL_MEASUREMENT_REFLN`
   - `structure_id`
- `SPACE_GROUP`
   - `id`
- `SPACE_GROUP_GENERATOR`, `SPACE_GROUP_SYMOP`, and `SPACE_GROUP_WYCKOFF`
   - `space_group_id`


`cell.diffrn_id` and `cell_measurement.diffrn_id` have been removed.

Modulated and magnetic structures need to be looked at.
