### PR TITLE
Allow multiple wavelengths in a single radiation source

### DIFF
--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -51,7 +51,7 @@ save_MULTIBLOCK_CORE
 
     _import.get
         [
-         {'dupl':Ignore  'file':cif_core.dic  'mode':Full  'save':CIF_CORE_HEAD}
+         {'dupl':Ignore  'file':cif_core.dic  'mode':Full  'save':CIF_CORE}
         ]
 
 save_
@@ -139,6 +139,47 @@ save_diffrn_radiation.diffrn_id
     _diffrn.id.
 ;
     _name.category_id             diffrn_radiation
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN_RADIATION_WAVELENGTH
+
+    _definition.id                DIFFRN_RADIATION_WAVELENGTH
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2024-11-12
+    _description.text
+;
+    The CATEGORY of data items which specify the wavelength of the
+    radiation used in measuring diffraction intensities. Items may be
+    looped to identify and assign weights to distinct wavelength
+    components from a polychromatic beam.
+;
+    _name.category_id             DIFFRN_RADIATION
+    _name.object_id               DIFFRN_RADIATION_WAVELENGTH
+    loop_
+      _category_key.name
+         '_diffrn_radiation_wavelength.id'
+         '_diffrn_radiation_wavelength.diffrn_id'
+
+save_
+
+save_diffrn_radiation_wavelength.diffrn_id
+
+    _definition.id                '_diffrn_radiation_wavelength.diffrn_id'
+    _definition.update            2024-11-12
+    _description.text
+;
+    Identifier for the diffraction conditions to which the listed wavelength
+    relates. This item is a pointer to _diffrn.id.
+;
+    _name.category_id             diffrn_radiation_wavelength
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _type.purpose                 Link


### PR DESCRIPTION
This is an experimental PR to show how multiple wavelengths (e.g. K alpha1, K alpha 2 or harmonics) can be associated with a single diffraction experiment (`_diffrn.id`). This is not currently possible in a multi-experiment CIF. This PR accomplishes that by adding a link to `_diffrn.id` to the `DIFFRN_RADIATION_WAVELENGTH` category. `_diffrn_radiation.wavelength_id` would also be deprecated in the core dictionary (not included here). Where information from a single `_diffrn.id` is in a single data block, `_diffrn_radiation_wavelength.diffrn_id` need not be supplied.

See also alternative PR accomplishing the same by splitting radiation definition out of `DIFFRN` category.