### PR TITLE
Make wavelength description independent of diffraction experiment

### DIFF
--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -148,27 +148,6 @@ save_DIFFRN_RADIATION
 
 save_
 
-save_diffrn_radiation.diffrn_id
-
-    _definition.id                '_diffrn_radiation.diffrn_id'
-    _definition_replaced.by       .
-    _definition.update            2024-11-12
-    _description.text
-;
-    **DEPRECATED** Unique identifier for a diffraction data set
-    collected under particular diffraction conditions. This item
-    is a pointer to _diffrn.id.
-;
-    _name.category_id             diffrn_radiation
-    _name.object_id               diffrn_id
-    _name.linked_item_id          '_diffrn.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
 save_diffrn_radiation.id
 
     _definition.id                '_diffrn_radiation.id'

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -114,7 +114,7 @@ save_DIFFRN_RADIATION
     _definition.id                DIFFRN_RADIATION
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2024-10-17
+    _definition.update            2024-11-12
     _description.text
 ;
     The CATEGORY of data items which specify the wavelength of the
@@ -124,23 +124,83 @@ save_DIFFRN_RADIATION
 ;
     _name.category_id             DIFFRACTION
     _name.object_id               DIFFRN_RADIATION
-    _category_key.name            '_diffrn_radiation.diffrn_id'
+    _category_key.name            '_diffrn_radiation.id'
 
 save_
 
 save_diffrn_radiation.diffrn_id
 
     _definition.id                '_diffrn_radiation.diffrn_id'
-    _definition.update            2024-10-17
+    _definition_replaced.by       .
+    _definition.update            2024-11-12
     _description.text
 ;
-    Unique identifier for a diffraction data set collected under
-    particular diffraction conditions. This item is a pointer to
-    _diffrn.id.
+    **DEPRECATED** Unique identifier for a diffraction data set
+    collected under particular diffraction conditions. This item
+    is a pointer to _diffrn.id.
 ;
     _name.category_id             diffrn_radiation
     _name.object_id               diffrn_id
     _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_radiation.id
+
+    _definition.id                '_diffrn_radiation.id'
+    _definition_replaced.by       .
+    _definition.update            2024-11-12
+    _description.text
+;
+    Unique identifier for this radiation description.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN_RADIATION_WAVELENGTH
+
+    _definition.id                DIFFRN_RADIATION_WAVELENGTH
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2024-11-12
+    _description.text
+;
+    The CATEGORY of data items which specify the wavelength of the
+    radiation used in measuring diffraction intensities. Items may be
+    looped to identify and assign weights to distinct wavelength
+    components from a polychromatic beam.
+;
+    _name.category_id             DIFFRN_RADIATION
+    _name.object_id               DIFFRN_RADIATION_WAVELENGTH
+    loop_
+      _category_key.name
+         '_diffrn_radiation_wavelength.id'
+         '_diffrn_radiation_wavelength.radiation_id'
+
+save_
+
+save_diffrn_radiation_wavelength.radiation_id
+
+    _definition.id                '_diffrn_radiation_wavelength.radiation_id'
+    _definition.update            2024-11-12
+    _description.text
+;
+    Code identifying the radiation description to which this wavelength
+    relates.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               radiation_id
+    _name.linked_item_id          '_diffrn_radiation.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -169,6 +169,24 @@ save_diffrn_radiation.diffrn_id
 
 save_
 
+save_diffrn_radiation.id
+
+    _definition.id                '_diffrn_radiation.id'
+    _definition_replaced.by       .
+    _definition.update            2024-11-15
+    _description.text
+;
+    Unique identifier for a radiation source description.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_DIFFRN_RADIATION_WAVELENGTH
 
     _definition.id                DIFFRN_RADIATION_WAVELENGTH

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -91,6 +91,26 @@ save_diffrn.crystal_id
 
 save_
 
+save_diffrn.diffrn_radiation_id
+
+    _definition.id                '_diffrn.diffrn_radiation_id'
+    _definition.update            2024-11-12
+    _description.text
+;
+    Identifies the characteristics of the radiation source
+    for the diffraction data. This is a pointer to
+    _diffrn_radiation.id.
+;
+    _name.category_id             diffrn
+    _name.object_id               diffrn_radiation_id
+    _name.linked_item_id          '_diffrn_radiation.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_diffrn.id
 
     _definition.id                '_diffrn.id'
@@ -144,24 +164,6 @@ save_diffrn_radiation.diffrn_id
     _name.linked_item_id          '_diffrn.id'
     _type.purpose                 Link
     _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_diffrn_radiation.id
-
-    _definition.id                '_diffrn_radiation.id'
-    _definition_replaced.by       .
-    _definition.update            2024-11-12
-    _description.text
-;
-    Unique identifier for this radiation description.
-;
-    _name.category_id             diffrn_radiation
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
 


### PR DESCRIPTION
Fixes issue #505, alternative to #18 .

This is an alternative way of associating more than one wavelength with a diffraction experiment that goes a bit deeper than #18. `DIFFRN_RADIATION` becomes independent of `DIFFRN` and then `DIFFRN` includes an explicit pointer to `_diffrn_radiation.id`.

The advantage of this approach, apart from the ability to specify multiple wavelengths as in #18 , is that radiation characteristics need be provided only once for multiple measurements using the same source. For example a multi-temperature experiment (imagine 100 temperature measurements) need only set the value of `_diffrn.diffrn_radiation_id` in the `diffrn` category of each measurement, instead of respecifying everything in `DIFFRN_RADIATION` and `DIFFRN_RADIATION_WAVELENGTH` for every temperature.

The drawback is that mmCIF already has defined `_diffrn_radiation.diffrn_id`, which this PR deprecates. As this data name has never appeared in a released core dictionary, non mmCIF software does not output it and will not try to interpret it if handed an mmCIF file. It can still be given a well-defined value if there is only one set of diffraction conditions and one source of radiation.