### PR TITLE
update diffrn.id to remove reference to dataset

### DIFF
--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -249,8 +249,7 @@ save_diffrn.id
     _definition.update            2022-05-09
     _description.text
 ;
-    Unique identifier for a diffraction data set collected under
-    particular diffraction conditions.
+    Unique identifier for a set of particular diffraction conditions.
 ;
     _name.category_id             diffrn
     _name.object_id               id


### PR DESCRIPTION
will close #17 

Makes diffrn.id an identifier for the set of diffraction conditions, not the dataset which used them.