### PR TITLE
add missing _

### DIFF
--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -303,7 +303,7 @@ save_
 
 save_diffrn_detector.diffrn_id
 
-    _definition.id                'diffrn_detector.diffrn_id'
+    _definition.id                '_diffrn_detector.diffrn_id'
     _definition.update            2025-06-30
     _description.text
 ;


### PR DESCRIPTION
Missed a `_` in the definition.id