### PR TITLE
Add diffrn_measurement category

### DIFF
--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -252,8 +252,9 @@ save_diffrn.diffrn_measurement_id
     _definition.update            2026-04-22
     _description.text
 ;
-    Identifies the positioner used to collect the diffraction data.
-    This is a pointer to _diffrn_measurement.id.
+    Identifies the particular combination of sample mount, positioner,
+    and scan strategy used to collect the diffraction data. This is a
+    pointer to _diffrn_measurement.id.
 ;
     _name.category_id             diffrn
     _name.object_id               diffrn_measurement_id

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -246,6 +246,25 @@ save_diffrn.crystal_id
 
 save_
 
+save_diffrn.diffrn_measurement_id
+
+    _definition.id                '_diffrn.diffrn_measurement_id'
+    _definition.update            2026-04-22
+    _description.text
+;
+    Identifies the positioner used to collect the diffraction data.
+    This is a pointer to _diffrn_measurement.id.
+;
+    _name.category_id             diffrn
+    _name.object_id               measurement_id
+    _name.linked_item_id          '_diffrn_measurement.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
 save_diffrn.diffrn_radiation_id
 
     _definition.id                '_diffrn.diffrn_radiation_id'
@@ -277,25 +296,6 @@ save_diffrn.id
     _name.category_id             diffrn
     _name.object_id               id
     _type.purpose                 Key
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
-
-save_
-
-save_diffrn.diffrn_measurement_id
-
-    _definition.id                '_diffrn.diffrn_measurement_id'
-    _definition.update            2026-04-22
-    _description.text
-;
-    Identifies the positioner used to collect the diffraction data.
-    This is a pointer to _diffrn_measurement.id.
-;
-    _name.category_id             diffrn
-    _name.object_id               measurement_id
-    _name.linked_item_id          '_diffrn_measurement.id'
-    _type.purpose                 Link
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Word

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -283,9 +283,9 @@ save_diffrn.id
 
 save_
 
-save_diffrn.positioner_id
+save_diffrn.diffrn_measurement_id
 
-    _definition.id                '_diffrn.positioner_id'
+    _definition.id                '_diffrn.diffrn_measurement_id'
     _definition.update            2026-04-22
     _description.text
 ;
@@ -293,7 +293,7 @@ save_diffrn.positioner_id
     This is a pointer to _diffrn_measurement.id.
 ;
     _name.category_id             diffrn
-    _name.object_id               positioner_id
+    _name.object_id               measurement_id
     _name.linked_item_id          '_diffrn_measurement.id'
     _type.purpose                 Link
     _type.source                  Assigned

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -256,7 +256,7 @@ save_diffrn.diffrn_measurement_id
     This is a pointer to _diffrn_measurement.id.
 ;
     _name.category_id             diffrn
-    _name.object_id               measurement_id
+    _name.object_id               diffrn_measurement_id
     _name.linked_item_id          '_diffrn_measurement.id'
     _type.purpose                 Link
     _type.source                  Assigned

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -328,7 +328,7 @@ save_diffrn_measurement.diffrn_id
     A link to a diffraction experiment with which this measurement
     strategy is associated. This is provided for backwards compatibility.
     Where multiple experiments are associated with a particular strategy,
-    use `_diffrn.positioner_id`.
+    use `_diffrn.diffrn_measurement_id`.
 ;
     _name.category_id             diffrn_measurement
     _name.object_id               diffrn_id

--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -10,10 +10,10 @@ data_MULTIBLOCK_DIC
     _dictionary.title             MULTIBLOCK_DIC
     _dictionary.class             Instance
     _dictionary.version           1.1.0
-    _dictionary.date              2026-01-19
+    _dictionary.date              2026-04-22
     _dictionary.uri
 ;\
-https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/\
+https://raw.githubusercontent.com/COMCIFS/cif_multiblock/main/\
 multi_block_core.dic
 ;
     _dictionary.ddl_conformance   4.2.0
@@ -280,6 +280,86 @@ save_diffrn.id
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
+
+save_
+
+save_diffrn.positioner_id
+
+    _definition.id                '_diffrn.positioner_id'
+    _definition.update            2026-04-22
+    _description.text
+;
+    Identifies the positioner used to collect the diffraction data.
+    This is a pointer to _diffrn_measurement.id.
+;
+    _name.category_id             diffrn
+    _name.object_id               positioner_id
+    _name.linked_item_id          '_diffrn_measurement.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN_MEASUREMENT
+
+    _definition.id                DIFFRN_MEASUREMENT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2026-04-22
+    _description.text
+;
+    The CATEGORY of data items used to describe the sample mounting
+    and positioning as well as the measurement strategy.
+;
+    _name.category_id             DIFFRACTION
+    _name.object_id               DIFFRN_MEASUREMENT
+    _category_key.name            '_diffrn_measurement.id'
+
+save_
+
+save_diffrn_measurement.diffrn_id
+
+    _definition.id                '_diffrn_measurement.diffrn_id'
+    _definition.update            2026-04-22
+    _description.text
+;
+    A link to a diffraction experiment with which this measurement
+    strategy is associated. This is provided for backwards compatibility.
+    Where multiple experiments are associated with a particular strategy,
+    use `_diffrn.positioner_id`.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_measurement.id
+
+    _definition.id                '_diffrn_measurement.id'
+    _definition.update            2026-04-22
+    _description.text
+;
+    Unique identifier for a particular combination of sample mount,
+    positioner, and scan strategy.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = _diffrn_measurement.device
+;
 
 save_
 
@@ -1419,7 +1499,7 @@ save_
 ;
        All multi-block items from core 3.2.0 added.
 ;
-         1.1.0                    2026-01-19
+         1.1.0                    2026-04-22
 ;
        # Update date above and add audit comments below. Remove
        this comment when ready for release.
@@ -1454,5 +1534,9 @@ save_
 
        Add DIFFRN_RADIATION category with _diffrn_radiation.id as key. Included
         _diffrn_radiation.diffrn_id to maintain compatibility with imgCIF.
+
+       Add DIFFRN_MEASUREMENT category with _diffrn_measurement.id as key.
+       Included _diffrn_measurement.diffrn_id to maintain compatibility with
+       imgCIF.
 ;
 


### PR DESCRIPTION
`diffrn_measurement` becomes a standalone top-level category, that is, independent of `diffrn`. Current mmCIF envisions `diffrn_measurement` as extra columns for `diffrn`, but this becomes unwieldy in contexts like powder diffraction, where many experiments may use the same positioning equipment.

I have chosen `_diffrn.positioner_id` to refer to `_diffrn_measurement.id` as the obvious `_diffrn.measurement_id` overlaps with the former when periods are converted to underscores, which might be used by programmers as a low-effort strategy to deal with the change to using periods in data names.

The present change to `diffrn_measurement` improves compatibility with imgCIF. The imgCIF dictionary currently wants both `_dm.id` and `_dm.device` to be alternative keys of the category. By specifying `_dm.device` as a default value for `_dm.id` in dREL we partially remedy the largely theoretical backwards compatibility issues.

See #42 for the original discussion.

A separate PR should add authors and licence for this dictionary to fix the CI failure.