### PR TITLE
add _diffrn_refln.diffrn_id

### DIFF
--- a/multi_block_core.dic
+++ b/multi_block_core.dic
@@ -11,7 +11,7 @@ data_MULTIBLOCK_DIC
     _dictionary.title             MULTIBLOCK_DIC
     _dictionary.class             Instance
     _dictionary.version           1.1.0
-    _dictionary.date              2026-05-19
+    _dictionary.date              2026-06-11
     _dictionary.uri
 ;\
 https://raw.githubusercontent.com/COMCIFS/cif_multiblock/main/\
@@ -674,6 +674,46 @@ save_diffrn_radiation_wavelength.radiation_id
     _name.linked_item_id          '_diffrn_radiation.id'
     _type.purpose                 Link
     _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN_REFLN
+
+    _definition.id                DIFFRN_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2026-06-11
+    _description.text
+;
+    The category of data items which specify the reflection measurements,
+    prior to data reduction and merging.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_REFLN
+
+    loop_
+      _category_key.name
+         '_diffrn_refln.diffrn_id'
+         '_diffrn_refln.id'
+
+save_
+
+save_diffrn_refln.diffrn_id
+
+    _definition.id                '_diffrn_refln.diffrn_id'
+    _definition.update            2026-06-11
+    _description.text
+;
+    A code which identifies the diffraction conditions under which the data for
+    reflection measurements were collected.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
     _type.container               Single
     _type.contents                Word
 
@@ -1554,7 +1594,7 @@ save_
 ;
        All multi-block items from core 3.2.0 added.
 ;
-         1.1.0                    2026-05-19
+         1.1.0                    2026-06-11
 ;
        # Update date above and add audit comments below. Remove
        this comment when ready for release.
@@ -1599,5 +1639,7 @@ save_
 
        Updated REFLN to include _refln.structure_id (linked to _structure.id)
        as a key data name.
+
+       Added _diffrn_refln.diffrn_id is linked key to DIFFRN_REFLN.
 ;
 


### PR DESCRIPTION
will close #51 

Added  _diffrn_refln.diffrn_id as linked key, forming composite key.

Required to enable the following missing link:

```
  !  FK: '_diffrn_refln.wavelength_id' -> '_diffrn_radiation_wavelength.id': partial FK to 'diffrn_radiation_wavelength' -- covers ['id'] of PKs=['id', 'radiation_id'], no transitive bridge found -- skipping FK constraint
```

without any jiggerypokery,