### PR TITLE
Removed AUDIT_DATASET

### DIFF
--- a/cif_core_multiblock.dic
+++ b/cif_core_multiblock.dic
@@ -11,7 +11,7 @@ data_CIF_CORE_MULTIBLOCK
     _dictionary.title             CIF_CORE_MULTIBLOCK
     _dictionary.class             Instance
     _dictionary.version           1.1.0
-    _dictionary.date              2026-06-17
+    _dictionary.date              2026-07-01
     _dictionary.uri
 ;\
 https://raw.githubusercontent.com/COMCIFS/cif_core_multiblock/main/\
@@ -58,158 +58,6 @@ save_CIF_CORE_MULTIBLOCK_HEAD
         [
          {'dupl':Ignore  'file':cif_core.dic  'mode':Full  'save':CIF_CORE_HEAD}
         ]
-
-save_
-
-save_AUDIT_DATASET
-
-    _definition.id                AUDIT_DATASET
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2025-04-14
-    _description.text
-;
-    The CATEGORY of data items used for linking data blocks to aid in grouping
-    blocks which contain information which are interrelated.
-
-    Data blocks which should be interpreted together are identified with the
-    same unique _audit_dataset.id.
-;
-    _name.category_id             AUDIT
-    _name.object_id               AUDIT_DATASET
-    _category_key.name            '_audit_dataset.id'
-
-    loop_
-      _description_example.case
-      _description_example.detail
-;
-         data_structure1
-         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
-         _pd_phase.name "First phase"
-         #cell parameters and atom positions
-         #...
-
-         data_structure2
-         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
-         _pd_phase.id "Second phase"
-         #cell parameters and atom positions
-         #...
-
-         data_diffraction_data1
-         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
-         _pd_diffractogram.id "First dataset"
-         #diffracted intensities vs angle
-         #...
-
-         data_information
-         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
-         #wavelength, specimen preparation, temperature, pressure...
-         #...
-;
-;
-         Four data blocks for a powder diffraction experiment.
-         By the presence of an identical _audit_dataset.id value, it is made
-         clear that all four data blocks are to be interpreted together as
-         a whole. It is clear that there are two crystal structures, one
-         diffractogram, and a block containing other experimental information.
-
-         These blocks may be contained in the same file, or many files, but
-         the presence of an _audit_dataset.id value removes doubt as to their
-         relationship to each other.
-;
-;
-         data_structure1
-         _pd_phase.name "First phase"
-         #cell parameters and atom positions
-         #...
-
-         data_structure2
-         _pd_phase.id "Second phase"
-         #cell parameters and atom positions
-         #...
-
-         data_diffraction_data1
-         _pd_diffractogram.id "First dataset"
-         #diffracted intensities vs angle
-         #...
-
-         data_information
-         #wavelength, specimen preparation, temperature, pressure...
-         #...
-;
-;
-         Four data blocks for a powder diffraction experiment.
-         The absence of an _audit_dataset.id value does not preclude
-         interpreting these data blocks together. The
-         consumer of the information may be able to infer that they belong
-         together due to contextual information.
-;
-;
-         data_structure1
-         _audit_dataset.id  34e58dee-900c-47cf-8f8c-1f52e5a9a3b9
-         _pd_phase.name "First phase"
-         #cell parameters and atom positions
-         #...
-
-         data_calibration_structure
-         loop_
-           _audit_dataset.id
-           34e58dee-900c-47cf-8f8c-1f52e5a9a3b9
-           2d7ee621-d916-4302-9045-ec68f56add45
-           255bb051-a3d5-43f0-8384-fa8ccb2ce3c7
-         _pd_phase.id "Calibration phase"
-         #cell parameters and atom positions
-         #...
-
-         data_diffraction_data
-         _audit_dataset.id  34e58dee-900c-47cf-8f8c-1f52e5a9a3b9
-         _pd_diffractogram.id "First dataset"
-         #diffracted intensities vs angle
-         #...
-;
-;
-         Three data blocks for a powder diffraction experiment.
-         The identical _audit_dataset.id value makes it
-         clear that all data blocks are to be interpreted together as
-         a whole. The presence of multiple _audit_dataset.id values for the
-         second data block indicates it is included in more than one dataset.
-
-         Because they have different
-         _audit_dataset.id values, the diffractogram _pd_diffractogram.id
-         "First dataset" in the first example is different to the diffractogram
-         _pd_diffractogram.id "First dataset" in this example.
-;
-
-save_
-
-save_audit_dataset.id
-
-    _definition.id                '_audit_dataset.id'
-    _definition.update            2025-04-14
-    _description.text
-;
-    Globally unique identifier for data blocks that are meant to be interpreted
-    together as a whole.
-
-    Data blocks which belong together, for instance, as they form part of the
-    same experiment, are given an identical _audit_dataset.id value.
-
-    Data blocks, such as calibration information, can be designated with more
-    than one _audit_dataset.id value.
-
-    Data blocks which do not contain an _audit_dataset.id may still be related,
-    depending on the presence of other data names and values. Data blocks which
-    contain different _audit_dataset.id values are not related in a CIF-sense,
-    even if other data names and values are common.
-
-    To ensure global uniqueness, a UUID-like identifier is suggested.
-;
-    _name.category_id             audit_dataset
-    _name.object_id               id
-    _type.purpose                 Key
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Word
 
 save_
 
@@ -1707,12 +1555,10 @@ save_
 ;
        All multi-block items from core 3.2.0 added.
 ;
-         1.1.0                    2026-06-17
+         1.1.0                    2026-07-01
 ;
        Add STRUCTURE and related data names and links, including
        REFLN, CELL, ATOM_SITE, and ATOM_SITES_* categories.
-
-       Added AUDIT_DATASET.
 
        Added _model.id as key to MODEL and added child key data names
        to GEOM_* and MODEL_SITE categories.


### PR DESCRIPTION
`AUDIT_DATASET` has been moved to the main dictionary as per #23 . See also https://github.com/COMCIFS/cif_core/pull/625.