### PR TITLE
change to 'save':structure_id_key

### DIFF
--- a/cif_core_multiblock.dic
+++ b/cif_core_multiblock.dic
@@ -81,19 +81,11 @@ save_
 save_atom_sites.structure_id
 
     _definition.id                '_atom_sites.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with this atom
-    sites description.
-;
     _name.category_id             atom_sites
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 
@@ -344,19 +336,11 @@ save_
 save_cell.structure_id
 
     _definition.id                '_cell.structure_id'
-    _definition.update            2024-02-05
-    _description.text
-;
-    A code identifying the crystallographic structure associated with this cell
-    description.
-;
     _name.category_id             cell
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 

--- a/cif_core_multiblock.dic
+++ b/cif_core_multiblock.dic
@@ -11,7 +11,7 @@ data_CIF_CORE_MULTIBLOCK
     _dictionary.title             CIF_CORE_MULTIBLOCK
     _dictionary.class             Instance
     _dictionary.version           1.1.1-dev
-    _dictionary.date              2026-07-01
+    _dictionary.date              2026-07-08
     _dictionary.uri
 ;\
 https://raw.githubusercontent.com/COMCIFS/cif_core_multiblock/main/\
@@ -1523,8 +1523,10 @@ save_
        Renamed dictionary to CIF_CORE_MULTIBLOCK and adjusted the head
        category name accordingly.
 ;
-         1.1.1-dev                2026-07-01
+         1.1.1-dev                2026-07-08
 ;
        # Add update summary below and change date above until ready for
        # release.
+
+       Altered *.structure_id save frames to use imported saveframe.
 ;

--- a/cif_core_multiblock.dic
+++ b/cif_core_multiblock.dic
@@ -112,10 +112,9 @@ save_atom_sites_cartn_transform.structure_id
     _definition.id                '_atom_sites_Cartn_transform.structure_id'
     _name.category_id             atom_sites_Cartn_transform
     _name.object_id               structure_id
-    _name.linked_item_id          '_atom_sites.structure_id'
 
     _import.get
-        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 
@@ -142,10 +141,9 @@ save_atom_sites_fract_transform.structure_id
     _definition.id                '_atom_sites_fract_transform.structure_id'
     _name.category_id             atom_sites_fract_transform
     _name.object_id               structure_id
-    _name.linked_item_id          '_atom_sites.structure_id'
 
     _import.get
-        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 
@@ -396,10 +394,9 @@ save_cell_measurement.structure_id
     _definition.id                '_cell_measurement.structure_id'
     _name.category_id             cell_measurement
     _name.object_id               structure_id
-    _name.linked_item_id          '_cell.structure_id'
 
     _import.get
-        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 
@@ -431,10 +428,9 @@ save_cell_measurement_refln.structure_id
     _definition.id                '_cell_measurement_refln.structure_id'
     _name.category_id             cell_measurement_refln
     _name.object_id               structure_id
-    _name.linked_item_id          '_cell_measurement.structure_id'
 
     _import.get
-        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 

--- a/cif_core_multiblock.dic
+++ b/cif_core_multiblock.dic
@@ -1465,18 +1465,11 @@ save_
 save_atom_site.structure_id
 
     _definition.id                '_atom_site.structure_id'
-    _definition.update            2023-10-16
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
     _name.category_id             atom_site
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key}]
 
 save_
 

--- a/cif_core_multiblock.dic
+++ b/cif_core_multiblock.dic
@@ -110,19 +110,12 @@ save_
 save_atom_sites_cartn_transform.structure_id
 
     _definition.id                '_atom_sites_Cartn_transform.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with this atom
-    sites Cartesian coordinate transform.
-;
     _name.category_id             atom_sites_Cartn_transform
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+    _name.linked_item_id          '_atom_sites.structure_id'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
 
 save_
 
@@ -147,19 +140,12 @@ save_
 save_atom_sites_fract_transform.structure_id
 
     _definition.id                '_atom_sites_fract_transform.structure_id'
-    _definition.update            2026-06-15
-    _description.text
-;
-    A code identifying the crystallographic structure associated with this atom
-    sites fractional coordinate transform.
-;
     _name.category_id             atom_sites_fract_transform
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+    _name.linked_item_id          '_atom_sites.structure_id'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
 
 save_
 
@@ -408,18 +394,12 @@ save_
 save_cell_measurement.structure_id
 
     _definition.id                '_cell_measurement.structure_id'
-    _definition.update            2024-02-05
-    _description.text
-;
-    A code identifying the structure to which the cell being measured belongs.
-;
     _name.category_id             cell_measurement
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+    _name.linked_item_id          '_cell.structure_id'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
 
 save_
 
@@ -449,18 +429,12 @@ save_
 save_cell_measurement_refln.structure_id
 
     _definition.id                '_cell_measurement_refln.structure_id'
-    _definition.update            2023-10-16
-    _description.text
-;
-    A code identifying the structure for which the reflections were measured.
-;
     _name.category_id             cell_measurement_refln
     _name.object_id               structure_id
-    _name.linked_item_id          '_structure.id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+    _name.linked_item_id          '_cell_measurement.structure_id'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
 
 save_
 
@@ -1497,18 +1471,12 @@ save_
 save_atom_site_aniso.structure_id
 
     _definition.id                '_atom_site_aniso.structure_id'
-    _definition.update            2023-10-16
-    _description.text
-;
-    A code identifying the structure to which this atom site belongs.
-;
     _name.category_id             atom_site_aniso
     _name.object_id               structure_id
     _name.linked_item_id          '_atom_site.structure_id'
-    _type.purpose                 Link
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Word
+
+    _import.get
+        [{'file':templ_attr.cif  'save':structure_id_key_no_linked}]
 
 save_
 


### PR DESCRIPTION
Altered save frame text to pull from templ_attrs.cif as per discussion in https://github.com/COMCIFS/cif_ms/pull/68#pullrequestreview-4651548824

_model.structure_id left alone as it is a non-key data name.